### PR TITLE
Rename VTL mapping template helper

### DIFF
--- a/examples/__tests__/appSync.test.ts
+++ b/examples/__tests__/appSync.test.ts
@@ -1,4 +1,4 @@
-import { vtlMappingTemplate } from 'sls-jest';
+import { appSyncMappingTemplate } from 'sls-jest';
 
 const template = `
 #set($id=$ctx.args.id)
@@ -17,7 +17,7 @@ describe('Mapping Template', () => {
 
     // test that the template evaluates to the expected value as a string
     await expect(
-      vtlMappingTemplate({
+      appSyncMappingTemplate({
         template,
         context: {
           arguments: {
@@ -31,7 +31,7 @@ describe('Mapping Template', () => {
   it('should evaluate a template object', async () => {
     // test that the template evaluates to the expected value as an object
     await expect(
-      vtlMappingTemplate({
+      appSyncMappingTemplate({
         template,
         context: {
           arguments: {
@@ -46,7 +46,7 @@ describe('Mapping Template', () => {
     // test that the template evaluates to the expected snapshot
     // if the snapshot evaluates to an object, it is parsed before being saved
     await expect(
-      vtlMappingTemplate({
+      appSyncMappingTemplate({
         template,
         context: {
           arguments: {
@@ -61,7 +61,7 @@ describe('Mapping Template', () => {
     // test that the template evaluates to the expected inline snapshot
     // if the snapshot evaluates to an object, it is parsed before being saved
     await expect(
-      vtlMappingTemplate({
+      appSyncMappingTemplate({
         template,
         context: {
           arguments: {
@@ -79,7 +79,7 @@ describe('Mapping Template', () => {
   it('should evaluate a template snapshot as string', async () => {
     // test that the template evaluates to the expected snapshot
     await expect(
-      vtlMappingTemplate({
+      appSyncMappingTemplate({
         template: 'hello ${ctx.args.id}',
         context: {
           arguments: {
@@ -93,7 +93,7 @@ describe('Mapping Template', () => {
   it('should evaluate a template inline snapshot', async () => {
     // test that the template evaluates to the expected inline snapshot
     await expect(
-      vtlMappingTemplate({
+      appSyncMappingTemplate({
         template: 'hello ${ctx.args.id}',
         context: {
           arguments: {

--- a/src/helpers/appsync.ts
+++ b/src/helpers/appsync.ts
@@ -9,9 +9,9 @@ import { O } from 'ts-toolbelt';
 import { z } from 'zod';
 
 /**
- * AppSync VTL template helper input
+ * AppSync mapping template helper input
  */
-export type VtlTemplateInput = {
+export type AppSyncMappingTemplateInput = {
   template: string;
   context: O.Partial<
     AppSyncResolverEvent<Record<string, unknown>, Record<string, unknown>>,
@@ -21,29 +21,30 @@ export type VtlTemplateInput = {
 };
 
 /**
- * VTL Template schema
+ * Mapping Template schema
  */
-const vtlTemplateInputSchema: HelperZodSchema<typeof vtlMappingTemplate> =
-  z.object({
-    template: z.string(),
-    context: z.object({}),
-  });
+const appSyncMappingTemplateInputSchema: HelperZodSchema<
+  typeof appSyncMappingTemplate
+> = z.object({
+  template: z.string(),
+  context: z.object({}),
+});
 
 /**
- * AppSync VTL template helper
+ * AppSync mapping template helper
  */
-export const vtlMappingTemplate: MatcherHelper<
-  'vtlMappingTemplate',
-  VtlTemplateInput
+export const appSyncMappingTemplate: MatcherHelper<
+  'appSyncMappingTemplate',
+  AppSyncMappingTemplateInput
 > = (input) => {
   assertMatcherHelperInputValue(
-    'vtlMappingTemplate',
-    vtlTemplateInputSchema,
+    'appSyncMappingTemplate',
+    appSyncMappingTemplateInputSchema,
     input,
   );
 
   return {
-    _helperName: 'vtlMappingTemplate',
+    _helperName: 'appSyncMappingTemplate',
     ...input,
   };
 };

--- a/src/helpers/internal.ts
+++ b/src/helpers/internal.ts
@@ -1,6 +1,6 @@
 import AsyncRetry from 'async-retry';
 import { reduce } from 'lodash';
-import { z, ZodType, ZodTypeAny, ZodTypeDef } from 'zod';
+import { z, ZodType } from 'zod';
 
 /**
  * Helper input schema utility type
@@ -12,7 +12,7 @@ export type HelperZodSchema<T extends (...args: any) => any> = z.ZodType<
 /**
  * Helper input type names
  */
-export type ItemType = 'dynamodbItem' | 'vtlMappingTemplate';
+export type ItemType = 'dynamodbItem' | 'appSyncMappingTemplate';
 
 /**
  * Matcher helper input

--- a/src/matchers/appSync.ts
+++ b/src/matchers/appSync.ts
@@ -15,7 +15,7 @@ import { toMatchInlineSnapshot, toMatchSnapshot } from 'jest-snapshot';
 import { equals, subsetEquality, iterableEquality } from '@jest/expect-utils';
 import { maybeParseJson } from './utils';
 import { canonicalize } from 'json-canonicalize';
-import { VtlTemplateInput } from '../helpers/appsync';
+import { AppSyncMappingTemplateInput } from '../helpers/appsync';
 import { assertMatcherHelperInputType } from '../helpers/internal';
 
 const EXPECTED_LABEL = 'Expected';
@@ -34,10 +34,14 @@ const getAppSyncClient = (config: AppSyncClientConfig = {}) => {
 
 export const toEvaluateTo = async function (
   this: MatcherState,
-  input: VtlTemplateInput,
+  input: AppSyncMappingTemplateInput,
   expected: string | object,
 ) {
-  assertMatcherHelperInputType('toEvaluateTo', ['vtlMappingTemplate'], input);
+  assertMatcherHelperInputType(
+    'toEvaluateTo',
+    ['appSyncMappingTemplate'],
+    input,
+  );
 
   const matcherName = 'toEvaluateTo';
   const options: MatcherHintOptions = {
@@ -85,12 +89,12 @@ export const toEvaluateTo = async function (
 
 export const toEvaluateToSnapshot = async function (
   this: MatcherState,
-  input: VtlTemplateInput,
+  input: AppSyncMappingTemplateInput,
   ...rest: any
 ) {
   assertMatcherHelperInputType(
     'toEvaluateToSnapshot',
-    ['vtlMappingTemplate'],
+    ['appSyncMappingTemplate'],
     input,
   );
   const client = getAppSyncClient(input.clientConfig);
@@ -108,12 +112,12 @@ export const toEvaluateToSnapshot = async function (
 
 export const toEvaluateToInlineSnapshot = async function (
   this: MatcherState,
-  input: VtlTemplateInput,
+  input: AppSyncMappingTemplateInput,
   ...rest: any
 ) {
   assertMatcherHelperInputType(
     'toEvaluateToInlineSnapshot',
-    ['vtlMappingTemplate'],
+    ['appSyncMappingTemplate'],
     input,
   );
   const client = getAppSyncClient(input.clientConfig);


### PR DESCRIPTION
`appSyncMappingTemplate` is more accurate and leaves the possibility for JS mapping templates
Also, it leaves the door open for a possible `apiGatewayMappingTemplate` helper