### PR TITLE
refactor(spy): make config parameter optional

### DIFF
--- a/src/spies/eventBridge/CloudWatchLogsEventSpy.ts
+++ b/src/spies/eventBridge/CloudWatchLogsEventSpy.ts
@@ -10,7 +10,7 @@ import { EventBridgeSpy, EventBridgeSpyConfig } from './EventBridgeSpy';
 export type CloudWatchEventSpyConfig = EventBridgeSpyConfig & {
   logGroupName: string;
   interval?: number;
-  clientConfig: CloudWatchLogsClientConfig;
+  clientConfig?: CloudWatchLogsClientConfig;
 };
 
 /**


### PR DESCRIPTION
This fix will allow the user to not explicitly (or be forced) to pass an empty `config` option when creating a new `eventBridgeSpy`.

Right now, TS will complain because `config` is required
<img width="322" alt="image" src="https://user-images.githubusercontent.com/3085156/194353525-08c18e01-1112-4f58-8780-71093d110d77.png">

This is what I did in another project to bypass this error and I didn't like it.
<img width="330" alt="image" src="https://user-images.githubusercontent.com/3085156/194353694-9b07d411-de3e-43e0-9133-97f58321c47a.png">

It would be nice if I can just do this:
```ts
spy = await eventBridgeSpy({
  eventBusName: EVENT_BRIDGE_NAME,
});
```