### PR TITLE
fix(spy): fix "undefined" issue in the generated stack name

### DIFF
--- a/src/infrastructure/stack-manager/event-bridge.ts
+++ b/src/infrastructure/stack-manager/event-bridge.ts
@@ -11,7 +11,7 @@ export const getEventBridgeSpyStack = (params: {
     throw new Error('"busName" parameter is required');
   }
 
-  const stackSuffix = `eb-spy-${params.busName}-${params.adapter}`;
+  const stackSuffix = `eb-spy-${busName}-${adapter}`;
 
   const stackDetails = getStackDetails({
     stackSuffix,


### PR DESCRIPTION
When the [adapter](https://github.com/serverless-guru/sls-jest/blob/6e0c057c075643bf587af3f6548a412b7db10af2/src/infrastructure/stack-manager/event-bridge.ts#L6) input is not passed, the generated stack name will contain `undefined` 👇🏻 

![image](https://user-images.githubusercontent.com/3085156/197363911-308c682d-5ca1-4e87-aa08-85e913825b85.png)

It's already been [taken into consideration](https://github.com/serverless-guru/sls-jest/blob/6e0c057c075643bf587af3f6548a412b7db10af2/src/infrastructure/stack-manager/event-bridge.ts#L8) but probably changed by mistake during the recent updates, this PR should fix the issue.
