### PR TITLE
docs(general): Fix typos in documentation

### DIFF
--- a/doc/cookbooks/github-actions.md
+++ b/doc/cookbooks/github-actions.md
@@ -5,7 +5,7 @@ description: >-
 
 # Deploy feauture ephemeral stacks
 
-You can use Github Actions to run your tests against an ephemeral stack each time you open a new Pul Request and push new code to it.
+You can use Github Actions to run your tests against an ephemeral stack each time you open a new Pull Request and push new code to it.
 
 ```yaml
 name: Deploy and run tests
@@ -45,7 +45,7 @@ jobs:
 
       # Deploy to a unique stack for each Pull Request
       - name: Deploy
-        run: sls deploy --stage ci${{ github.event.pull_request.number }} # or cdk deploy --all or whatever
+        run: sls deploy --stage ci${{ github.event.pull_request.number }} # or cdk deploy --all or a deploy command that makes sense for your stack
 
       # run tests
       - name: Integration tests
@@ -96,5 +96,5 @@ jobs:
         run: npx sls-jest destroy --tag ci${{ github.event.pull_request.number }}
 
       - name: Destroy stack
-        run: sls remove --stage ci${{ github.event.pull_request.number }} # or cdk destroy --all --force or whatever
+        run: sls remove --stage ci${{ github.event.pull_request.number }} # or cdk destroy --all --force or a remove/destroy command that makes sense for your stack
 ```

--- a/doc/core-concepts.md
+++ b/doc/core-concepts.md
@@ -12,7 +12,7 @@ Basic validation is also done on the values that are passed in the helper functi
 
 - **Reuseability**
 
-Some matchers can be used with several sersources. e.g. You can do `expect(dynamodbItem(...)).toExist();` or `expect(s3Object(...)).toExist();`.
+Some matchers can be used with several resources. e.g. You can do `expect(dynamodbItem(...)).toExist();` or `expect(s3Object(...)).toExist();`.
 
 `sls-jest` uses those helpers to keep track of **what** you are intending to test and use the appropriate logic internally.
 

--- a/doc/matchers/appsync.md
+++ b/doc/matchers/appsync.md
@@ -58,7 +58,7 @@ await expect(
 
 ### `toEvaluateToSnapshot(propertiesOrHint?: string, hint?: string)`
 
-Asserts that the evaluated template matches the most recent snapshot. It works similarely to jest's [toMatchSnapshot](https://jestjs.io/docs/expect#tomatchsnapshotpropertymatchers-hint).
+Asserts that the evaluated template matches the most recent snapshot. It works similarly to jest's [toMatchSnapshot](https://jestjs.io/docs/expect#tomatchsnapshotpropertymatchers-hint).
 
 ```typescript
 await expect(
@@ -75,7 +75,7 @@ await expect(
 
 ### `toEvaluateToInlineSnapshot(propertiesOrHint?: string, hint?: string)`
 
-Asserts that the evaluated template matches the most recent snapshot. It works similarely to jest's [toMatchInlineSnapshot](https://jestjs.io/docs/expect#tomatchinlinesnapshotpropertymatchers-inlinesnapshot).
+Asserts that the evaluated template matches the most recent snapshot. It works similarly to jest's [toMatchInlineSnapshot](https://jestjs.io/docs/expect#tomatchinlinesnapshotpropertymatchers-inlinesnapshot).
 
 ```typescript
 await expect(

--- a/doc/matchers/dynamodb.md
+++ b/doc/matchers/dynamodb.md
@@ -26,7 +26,7 @@ await expect(
 
 ### `toExistAndMatchObject<E>(expected: DeepPartial<E>)`
 
-Asserts that an item exists in the given table, and matches a subset of the properties of an object. It works similarely to jest's [toMatchObject](https://jestjs.io/docs/expect#tomatchobjectobject).
+Asserts that an item exists in the given table, and matches a subset of the properties of an object. It works similarly to jest's [toMatchObject](https://jestjs.io/docs/expect#tomatchobjectobject).
 
 ```typescript
 await expect(
@@ -43,7 +43,7 @@ await expect(
 
 ### `toExistAndMatchSnapshot(propertiesOrHint?: string, hint?: string)`
 
-Asserts that an item exists in the given table, and that it matches the most recent snapshot. It works similarely to jest's [toMatchSnapshot](https://jestjs.io/docs/expect#tomatchsnapshotpropertymatchers-hint).
+Asserts that an item exists in the given table, and that it matches the most recent snapshot. It works similarly to jest's [toMatchSnapshot](https://jestjs.io/docs/expect#tomatchsnapshotpropertymatchers-hint).
 
 ```typescript
 await expect(
@@ -58,7 +58,7 @@ await expect(
 
 ### `toExistAndMatchInlineSnapshot(propertiesOrHint?: string, hint?: string)`
 
-Asserts that an item exists in the given table, and that it matches the most recent inline snapshot. It works similarely to jest's [toMatchInlineSnapshot](https://jestjs.io/docs/expect#tomatchinlinesnapshotpropertymatchers-inlinesnapshot).
+Asserts that an item exists in the given table, and that it matches the most recent inline snapshot. It works similarly to jest's [toMatchInlineSnapshot](https://jestjs.io/docs/expect#tomatchinlinesnapshotpropertymatchers-inlinesnapshot).
 
 ```typescript
 await expect(

--- a/doc/matchers/s3.md
+++ b/doc/matchers/s3.md
@@ -23,7 +23,7 @@ await expect(
 
 ### `toExistAndMatchObject<E>(expected: DeepPartial<E>)`
 
-Asserts that an object exists in the given bucket, and matches a subset of the properties of a javascript object. It works similarely to jest's [toMatchObject](https://jestjs.io/docs/expect#tomatchobjectobject).
+Asserts that an object exists in the given bucket, and matches a subset of the properties of a javascript object. It works similarly to jest's [toMatchObject](https://jestjs.io/docs/expect#tomatchobjectobject).
 
 Note: This matcher can only be used with S3 objects that contain JSON-like data. If the content of the file cannot be parsed to a valid JSON, an error will be thrown.
 
@@ -40,7 +40,7 @@ await expect(
 
 ### `toExistAndMatchSnapshot(propertiesOrHint?: string, hint?: string)`
 
-Asserts that an item exists in the given bucket, and that it matches the most recent snapshot. It works similarely to jest's [toMatchSnapshot](https://jestjs.io/docs/expect#tomatchsnapshotpropertymatchers-hint).
+Asserts that an item exists in the given bucket, and that it matches the most recent snapshot. It works similarly to jest's [toMatchSnapshot](https://jestjs.io/docs/expect#tomatchsnapshotpropertymatchers-hint).
 
 ```typescript
 await expect(
@@ -53,7 +53,7 @@ await expect(
 
 ### `toExistAndMatchInlineSnapshot(propertiesOrHint?: string, hint?: string)`
 
-Asserts that an object exists in the given bucket, and that it matches the most recent inline snapshot. It works similarely to jest's [toMatchInlineSnapshot](https://jestjs.io/docs/expect#tomatchinlinesnapshotpropertymatchers-inlinesnapshot).
+Asserts that an object exists in the given bucket, and that it matches the most recent inline snapshot. It works similarly to jest's [toMatchInlineSnapshot](https://jestjs.io/docs/expect#tomatchinlinesnapshotpropertymatchers-inlinesnapshot).
 
 ```typescript
 await expect(

--- a/doc/spies/eventbridge.md
+++ b/doc/spies/eventbridge.md
@@ -16,7 +16,7 @@ This helper creates a new spy for a given event bus. Parameters:
 
 Config:
 
-- `matcherDefaultTimeout`: The default timeout for event matchers, in milliseconds. Defaults to `10000`. This is the maximum time a matcher will wait until it determines whether the assertion succeeds or fails. Also see the [recommendations](#recommendations) below about timeouts.
+- `matcherDefaultTimeout`: The default timeout for event matchers, in milliseconds. Defaults to `10_000`. This is the maximum time a matcher will wait until it determines whether the assertion succeeds or fails. Also see the [recommendations](#recommendations) below about timeouts.
 
 **with the sqs adapter**:
 

--- a/doc/spies/eventbridge.md
+++ b/doc/spies/eventbridge.md
@@ -16,21 +16,21 @@ This helper creates a new spy for a given event bus. Parameters:
 
 Config:
 
-- `matcherDefaultTimeout`: The default timeout for event matchers, in milliseconds. Defaults to `10_000`. This is the maximum time a matcher will wait until it determines whether the assertion succeeds or fails. Also see the [recommendations](#recommendations) below about timeouts.
+- `matcherDefaultTimeout`: The default timeout for event matchers, in milliseconds. Defaults to `10000`. This is the maximum time a matcher will wait until it determines whether the assertion succeeds or fails. Also see the [recommendations](#recommendations) below about timeouts.
 
 **with the sqs adapter**:
 
-- `waitTimeSeconds`: number, optional: The maximum polling time of the sqs poller (uses long polling). Defaults to `20`. Must be between `0` (use short polling) and `20`. The spie will run long polling cycles until the spie is [stopped](#spy.stop)
+- `waitTimeSeconds`: number, optional: The maximum polling time of the sqs poller (uses long polling). Defaults to `20`. Must be between `0` (use short polling) and `20`. The spie will run long polling cycles until the spy is [stopped](#spy.stop)
 - `clientConfig`: [SQSClientConfig](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-sqs/interfaces/sqsclientconfig.html), optional. Custom AWS SDK config.
 
 **with the cloudwatch adapter**:
 
-- `interval`: number, optional: The interval at which the spy will pull logs from the log group. Defaults: `2000`
+- `interval`: number, optional: The interval at which the spy will pull logs from the log group. Defaults to `2000`
 - `clientConfig`: [CloudWatchLogsClientConfig](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-cloudwatch-logs/interfaces/cloudwatchlogsclientconfig.html), optional. Custom AWS SDK config.
 
 ## Usage
 
-The simplest and more efficient way to use EventBridge spies is to create them at the very beginning of your tests. i.e.: in a `beforeAll()` hook at the top of your file or a `describe` block. The first time you create a spy for a given configuration combination (`adapter` and `eventBusName`), a new CloudFormation stack will be deployed automatically with the necessary resources. Further usage of the same spy will re-use the already deployed resources, even across several files.
+The simplest and most efficient way to use EventBridge spies is to create them at the very beginning of your tests. i.e.: in a `beforeAll()` hook at the top of your file or a `describe` block. The first time you create a spy for a given configuration combination (`adapter` and `eventBusName`), a new CloudFormation stack will be deployed automatically with the necessary resources. Further usage of the same spy will re-use the already deployed resources, even across several files.
 
 ```typescript
 let spy: EventBridgeSpy;
@@ -140,7 +140,7 @@ Cons:
 
 Pros:
 
-- By default, events are retained in the log group for 1 day. That allows you to go and check what events where received as you write your tests. This can help finding issues or adjust [timeouts](#recommendations) for example
+- By default, events are retained in the log group for 1 day. That allows you to go and check what events where received as you write your tests. This can help find issues or adjust [timeouts](#recommendations) for example
 
 Cons:
 
@@ -153,7 +153,7 @@ In practice, because of the asynchronous nature of EventBridge, it is hard to co
 **Always use random ids and assert on them**
 
 By using random ids and matching them in your test, you are avoiding false positive and false negative results.
-For example, here is a good example of a bad test:
+For example, here is a bad test:
 
 ```typescript
 it('should see an orderCreated event - use case 1', async () => {
@@ -175,7 +175,7 @@ it('should see an orderCreated event - use case 2', async () => {
 
 Matching only against the `detail-type` is not specific enough. The second test might see the event from the previous one and return successfully, when in fact no event was placed in that scenario.
 
-better:
+A better a test would be:
 
 ```typescript
 it('should see an orderCreated event - use case 1', async () => {
@@ -209,11 +209,11 @@ it('should see an orderCreated event - use case 2', async () => {
 
 **Use adequate timeouts**
 
-When matchers evaluate an assertion, they wait up to a certain amount of time until the assertion can either be resolved, in which case the matcher returns immediately, or it times out and evaluates the assertion with the data it has at that moment. Using too short timeouts can cause false negatives or positives as events that affect the result might arrive shortly after. On the other hand, using too-long timeouts can artificially slow down your test suite in some cases. Playing with different timeouts can reduce this inconvenience. Finding the right timeout may vary depending on your architecture and use case.
+When matchers evaluate an assertion, they wait up to a certain amount of time until the assertion can either be resolved, in which case the matcher returns immediately, or it times out and evaluates the assertion with the data it has at that moment. Using too short timeouts can cause false negatives or false positives as events that affect the result might arrive shortly after. On the other hand, using too-long timeouts can artificially slow down your test suite in some cases. Playing with different timeouts can reduce this inconvenience. Finding the right timeout may vary depending on your architecture and use case.
 
 Cases where a long timeout can slow down your tests:
 
-- `expect(spy).not.toHaveEventMatchingObject(...)`: The macher must wait the full timeout in order to ensure the event is not seen.
+- `expect(spy).not.toHaveEventMatchingObject(...)`: The matcher must wait the full timeout in order to ensure the event is not seen.
 
 - `expect(spy).toHaveEventMatchingObjectTimes(..., 2)`: The matcher must make sure that no more than 2 events are received.
 

--- a/doc/spies/eventbridge.md
+++ b/doc/spies/eventbridge.md
@@ -175,7 +175,7 @@ it('should see an orderCreated event - use case 2', async () => {
 
 Matching only against the `detail-type` is not specific enough. The second test might see the event from the previous one and return successfully, when in fact no event was placed in that scenario.
 
-A better a test would be:
+A better test would be:
 
 ```typescript
 it('should see an orderCreated event - use case 1', async () => {

--- a/doc/utils/dynamodb.md
+++ b/doc/utils/dynamodb.md
@@ -31,7 +31,7 @@ Note: Under the hood, items are inserted [in batches](https://docs.aws.amazon.co
 
 Feeds several tables with the given data.
 
-`items` is an object of which the keys represent table names, and the values a `DynamoDBItemCollection`.
+The `items` parameter is an object of which the keys represent table names, and the values a `DynamoDBItemCollection`.
 
 ```typescript
 await feedTables({
@@ -66,7 +66,7 @@ Note: Under the hood, items are inserted [in batches](https://docs.aws.amazon.co
 
 Deletes all the items from a table. It is useful for cleaning up data between tests.
 
-`keys` represents the primary key (Partition Key and, optionally, the Sort Key). If not passed, `sls-jest` will try to infer it from the [table description](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeTable.html).
+`keys` represent the primary key (Partition Key and, optionally, the Sort Key). If not passed, `sls-jest` will try to infer it from the [table description](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeTable.html).
 
 example:
 
@@ -80,7 +80,7 @@ For TypeScript users, some types are also exported for your convenience.
 
 ### `DynamoDBItem`
 
-Represents a single DynaoDB item, represented as a plain JS object.
+Represents a single DynamoDB item, represented as a plain JS object.
 
 example:
 


### PR DESCRIPTION
# Fix documentation typos

This PR addresses some typos I found while reading the [docs](https://serverlessguru.gitbook.io/sls-jest/). I focused only on minor typos and small grammar that don't modify the general idea.

As an improvement for the future, I think some more context is missing in the "Getting started" on what `sls-jest` is and what it isn't, instead of jumping straight into the commands to install..