### PR TITLE
fix(cdk): fix cdk deploy command

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   },
   "author": "Serverless Guru LLC",
   "license": "ISC",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.2",
     "@types/aws-lambda": "^8.10.101",

--- a/src/infrastructure/stack-manager/index.ts
+++ b/src/infrastructure/stack-manager/index.ts
@@ -90,10 +90,7 @@ export const deployStack = (params: {
     `config=${config}`,
   ];
 
-  const { error, status, stderr } = spawnSync('npx', args, {
-    // Run CDK in the context of the sls-jest
-    cwd: __dirname,
-  });
+  const { error, status, stderr } = spawnSync('npx', args);
 
   if (status !== 0 || error) {
     if (error) {


### PR DESCRIPTION
cdk deploy stopped working on node > 18 with `cwd: __dirname,`.
Removing it works. 

cdk 16 being EOL, and this package is still in alpha, don't bother supporting it and go straight to >= 18